### PR TITLE
Clean up compiler warnings

### DIFF
--- a/lib/monad.ex
+++ b/lib/monad.ex
@@ -118,7 +118,6 @@ defmodule Monad do
   with a function that's missing the first argument. See the example below.
 
   """
-  use Behaviour
 
   @doc """
   Helper for defining monads.
@@ -265,8 +264,8 @@ defmodule Monad.Pipeline do
         quote location: :keep do
           # I think there should be no conflict with the variable used in `fn`,
           # but just to be sure let's use an odd variable name.
-          {bind(unquote(elem(x, 0)), fn _monad_pipebind_arg ->
-            unquote(Macro.pipe(quote do _monad_pipebind_arg end, elem(fc, 0), 0))
+          {bind(unquote(elem(x, 0)), fn monad_pipebind_arg ->
+            unquote(Macro.pipe(quote do monad_pipebind_arg end, elem(fc, 0), 0))
            end), 0}
         end
       end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Monad.Mixfile do
 
   def project do
     [app: :monad,
-     version: "1.0.4",
+     version: "1.0.5",
      name: "monad",
      description: "Monads and do-syntax for Elixir",
      source_url: "https://github.com/rmies/monad",

--- a/package.exs
+++ b/package.exs
@@ -1,9 +1,9 @@
 Expm.Package.new(name: "monad",
                  description: "Haskell style monads and do-syntax",
-                 version: "1.0.4",
+                 version: "1.0.5",
                  keywords: ["Elixir","library","monads","Haskell"],
                  maintainers: [[name: "Peter Minten",
                                 email: "peter.minten@online.nl"],
                                [name: "Michel Rijnders",
                                 email: "michel@ugly-syntax.org"]],
-                 repositories: [[github: "rmies/monad", tag: "1.0.4"]])
+                 repositories: [[github: "rmies/monad", tag: "1.0.5"]])


### PR DESCRIPTION
Closes #7, also removed duplicate use Behaviour.

@rmies I wasn't sure how you'd want to handle versioning. The README says git-flow, so I did a hotfix. Assuming that, it made sense to version bump to 1.0.5. If you disagree I can resubmit as a feature branch without the version bumps.