### PR TITLE
Match __block__ as atom

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ env:
 otp_release:
   - 17.1
   - 17.0
-  - 20
+  - 19.0
 before_install:
   - mkdir -p vendor/elixir
   - wget -q https://github.com/elixir-lang/elixir/releases/download/$ELIXIR_VER/Precompiled.zip && unzip -qq Precompiled.zip -d vendor/elixir

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: erlang
 env:
-  - ELIXIR_VER=v1.0.2
+  - ELIXIR_VER=v1.4.5
 otp_release:
   - 17.1
   - 17.0
+  - 20
 before_install:
   - mkdir -p vendor/elixir
   - wget -q https://github.com/elixir-lang/elixir/releases/download/$ELIXIR_VER/Precompiled.zip && unzip -qq Precompiled.zip -d vendor/elixir

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,11 @@
-language: erlang
-env:
-  - ELIXIR_VER=v1.4.5
+language: elixir
+elixir:
+  - 1.4.5
 otp_release:
   - 18.0
   - 19.0
   - 20.0
 before_install:
-  - mkdir -p vendor/elixir
-  - wget -q https://github.com/elixir-lang/elixir/releases/download/$ELIXIR_VER/Precompiled.zip && unzip -qq Precompiled.zip -d vendor/elixir
-  - export PATH="$PATH:$PWD/vendor/elixir/bin"
   - mix archive.install http://s3.hex.pm/installs/hex.ez --force
   - export MIX_ENV=test
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: erlang
 env:
   - ELIXIR_VER=v1.4.5
 otp_release:
-  - 17.1
-  - 17.0
+  - 18.0
   - 19.0
+  - 20.0
 before_install:
   - mkdir -p vendor/elixir
   - wget -q https://github.com/elixir-lang/elixir/releases/download/$ELIXIR_VER/Precompiled.zip && unzip -qq Precompiled.zip -d vendor/elixir

--- a/lib/monad.ex
+++ b/lib/monad.ex
@@ -244,7 +244,7 @@ defmodule Monad.Pipeline do
             raise ArgumentError, message:
               "Monad.p called with a list but it's not a keyword list with " <>
               "a 'do' key (i.e. not a passed do block)"
-          { __block__, _, [expr] }    -> p_expand(expr)
+          {:__block__, _, [expr] }    -> p_expand(expr)
           expr                        -> p_expand(expr)
         end
       end

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Monad.Mixfile do
      description: "Monads and do-syntax for Elixir",
      source_url: "https://github.com/rmies/monad",
      package: package,
-     elixir: "~> 1.0",
+     elixir: "~> 1.4",
      deps: deps]
   end
 


### PR DESCRIPTION
With Elixir 1.6 this breaks compilation because `__block__` is reserved.

I updated it to use `:__block__` like is being used elsewhere in the module