### PR TITLE
Fix warnings

### DIFF
--- a/lib/monad.ex
+++ b/lib/monad.ex
@@ -1,6 +1,4 @@
 defmodule Monad do
-  use Behaviour
-
   @moduledoc """
   Behaviour that provides monadic do-notation and pipe-notation.
 
@@ -155,12 +153,12 @@ defmodule Monad do
   @doc """
   Inject a value into a monad.
   """
-  defcallback return(any) :: monad
+  @callback return(any) :: monad
 
   @doc """
   Bind a value in the monad to the passed function which returns a new monad.
   """
-  defcallback bind(monad, (any -> monad)) :: monad
+  @callback bind(monad, (any -> monad)) :: monad
 end
 
 defmodule Monad.Internal do
@@ -228,7 +226,6 @@ defmodule Monad.Pipeline do
   Just use `use Monad.Pipeline` in your monad module and define `return/1` and
   `bind/2` and get `pipebind/2` for free.
   """
-  use Behaviour
 
   defmacro __using__(_opts) do
     quote location: :keep do
@@ -278,5 +275,5 @@ defmodule Monad.Pipeline do
   Like bind/2 but works on ASTs and the second argument should be a function
   call where the first argument is missing.
   """
-  defcallback pipebind(Macro.t, Macro.t) :: Macro.t
+  @callback pipebind(Macro.t, Macro.t) :: Macro.t
 end

--- a/lib/monad/reader.ex
+++ b/lib/monad/reader.ex
@@ -13,7 +13,7 @@ defmodule Monad.Reader do
       iex> import Reader
       iex> r = Reader.m do
       ...>       let a = 2
-      ...>       b <- ask
+      ...>       b <- ask()
       ...>       return a + b
       ...>     end
       iex> Reader.run(10, r)

--- a/lib/monad/state.ex
+++ b/lib/monad/state.ex
@@ -14,7 +14,7 @@ defmodule Monad.State do
       iex> require Monad.State, as: State
       iex> import State
       iex> s = State.m do
-      ...>       a <- get
+      ...>       a <- get()
       ...>       put (a + 1)
       ...>       return a + 10
       ...>     end

--- a/lib/monad/writer.ex
+++ b/lib/monad/writer.ex
@@ -1,6 +1,4 @@
 defmodule Monad.Writer do
-  use Behaviour
-
   @moduledoc """
   The Writer monad.
 
@@ -82,10 +80,10 @@ defmodule Monad.Writer do
   @doc """
   Returns an initial output value.
   """
-  defcallback initial() :: output
+  @callback initial() :: output
 
   @doc """
   Adds a new piece of output to the output list.
   """
-  defcallback combine(output, output) :: output
+  @callback combine(output, output) :: output
 end

--- a/lib/monad/writer.ex
+++ b/lib/monad/writer.ex
@@ -17,7 +17,7 @@ defmodule Monad.Writer do
 
       # Outside the module.
       defmodule ListWriter do
-        def initial, do: []
+        def initial(), do: []
         def combine(new, acc), do: acc ++ new
       end
 
@@ -61,7 +61,7 @@ defmodule Monad.Writer do
       end
 
       @spec return(any) :: W.writer_m
-      def return(x), do: fn -> { x, initial } end
+      def return(x), do: fn -> { x, initial() } end
 
       @doc """
       Run the writer. Returns the return value and the output value.

--- a/mix.exs
+++ b/mix.exs
@@ -13,18 +13,18 @@ defmodule Monad.Mixfile do
   end
 
   # Configuration for the OTP application
-  def application do
+  def application() do
     []
   end
 
   # Returns the list of dependencies in the format:
   # { :foobar, "~> 0.1", git: "https://github.com/elixir-lang/foobar.git" }
-  defp deps do
+  defp deps() do
     [{:ex_doc, "~> 0.6.2", only: :dev},
      {:earmark, github: "pragdave/earmark", only: :dev}]
   end
 
-  defp package do
+  defp package() do
     [contributors: ["Wojciech Kaczmarek", "Peter Minten", "Michel Rijnders"],
      licenses: ["MIT"],
      links: %{"GitHub" => "https://github.com/rmies/monad"}]

--- a/test/monad/reader_test.exs
+++ b/test/monad/reader_test.exs
@@ -27,25 +27,25 @@ defmodule Monad.ReaderTest do
   test "Monad.Reader ask" do
     assert run(4, (Reader.m do
                      x <- return 2
-                     y <- ask
+                     y <- ask()
                      return (x * y)
                    end)) == 8
   end
 
   test "Monad.Reader local" do
-    assert run(4, (local(ask, &(&1+1)))) == 5
+    assert run(4, (local(ask(), &(&1+1)))) == 5
   end
 
   defp reader_times(x) do
     Reader.m do
-      y <- ask
+      y <- ask()
       return(x * y)
     end
   end
 
   defp reader_minus(x) do
     Reader.m do
-      y <- ask
+      y <- ask()
       return(x - y)
     end
   end
@@ -53,8 +53,8 @@ defmodule Monad.ReaderTest do
   test "Monad.Reader pipeline with do" do
     r = Monad.Reader.p do
       return(3)
-      |> reader_times
-      |> reader_minus
+      |> reader_times()
+      |> reader_minus()
     end
 
     assert run(10, r) == 20

--- a/test/monad/state_test.exs
+++ b/test/monad/state_test.exs
@@ -27,7 +27,7 @@ defmodule Monad.StateTest do
   test "Monad.State get and put" do
     assert run(4, (State.m do
                      let x = 2
-                     y <- get
+                     y <- get()
                      put x
                      return (x * y)
                    end)) == {8, 2}

--- a/test/monad/writer_test.exs
+++ b/test/monad/writer_test.exs
@@ -1,11 +1,11 @@
 defmodule WList do
   use Monad.Writer
-  def initial, do: []
+  def initial(), do: []
   def combine(new, acc), do: acc ++ new
 end
 
 defmodule Monad.WriterTest do
-  use ExUnit.Case, async: true 
+  use ExUnit.Case, async: true
 
   doctest Monad.Writer
 


### PR DESCRIPTION
Updates code style for newer Elixir versions.
This does not get rid of warnings in dependencies though.
Ran unit tests to check if everything still works.

Also fixes #12 and #13.